### PR TITLE
undefined method RSpec.configure

### DIFF
--- a/lib/factory_girl/preload/rspec2.rb
+++ b/lib/factory_girl/preload/rspec2.rb
@@ -1,3 +1,5 @@
+require 'rspec/core'
+
 RSpec.configure do |config|
   config.include Factory::Preload::Helpers
   config.before(:suite) do


### PR DESCRIPTION
Add require to 'rspec/core' (as insurance) to stop `undefined method RSpec.configure` error.    
