### PR TITLE
PostgreSQL compatibility

### DIFF
--- a/lib/factory_girl/preload.rb
+++ b/lib/factory_girl/preload.rb
@@ -25,9 +25,9 @@ module Factory
     end
 
     def self.clean(*names)
-      query = ActiveRecord::Base.connection.class.name == "ActiveRecord::ConnectionAdapters::SQLite3Adapter" ? "DELETE FROM `%s`" : "TRUNCATE TABLE `%s`"
+      query = ActiveRecord::Base.connection.class.name == "ActiveRecord::ConnectionAdapters::SQLite3Adapter" ? "DELETE FROM %s" : "TRUNCATE TABLE %s"
       names = ActiveRecord::Base.descendants.collect(&:table_name).uniq if names.empty?
-      names.each {|table| ActiveRecord::Base.connection.execute(query % table)}
+      names.each {|table| ActiveRecord::Base.connection.execute(query % ActiveRecord::Base.connection.quote_table_name(table))}
     end
 
     def self.reload_factories


### PR DESCRIPTION
PostgreSQL doesn't like `` quotes. Make it use AR adapters' `quote_table_name` instead.
