### PR TITLE
Turned off referential integrity

### DIFF
--- a/lib/factory_girl/preload.rb
+++ b/lib/factory_girl/preload.rb
@@ -31,7 +31,9 @@ module Factory
         else "TRUNCATE TABLE %s"
       end
       names = ActiveRecord::Base.descendants.collect(&:table_name).uniq if names.empty?
-      names.each {|table| ActiveRecord::Base.connection.execute(query % ActiveRecord::Base.connection.quote_table_name(table))}
+      ActiveRecord::Base.connection.disable_referential_integrity do
+        names.each {|table| ActiveRecord::Base.connection.execute(query % ActiveRecord::Base.connection.quote_table_name(table))}
+      end
     end
 
     def self.reload_factories


### PR DESCRIPTION
Turned off referential integrity to clean up the database.
For example, where there is the use of foreign keys.
