### PR TITLE
Avoid class lookup collisions

### DIFF
--- a/lib/factory_girl/preload/helpers.rb
+++ b/lib/factory_girl/preload/helpers.rb
@@ -15,7 +15,7 @@ module FactoryGirl
 
           class_eval <<-RUBY, __FILE__, __LINE__
             def #{method_name}(name)
-              factory(name, #{model})
+              factory(name, ::#{model})
             end
           RUBY
         end

--- a/spec/factory_girl/preload_spec.rb
+++ b/spec/factory_girl/preload_spec.rb
@@ -21,6 +21,10 @@ describe FactoryGirl::Preload do
     skills(:ruby).should be_a(Skill)
   end
 
+  it "returns :my factory for Preload model" do
+    preloads(:my).should be_a(Preload)
+  end
+
   it "reuses existing factories" do
     skills(:ruby).user.should == users(:john)
   end

--- a/spec/support/app/app/models/preload.rb
+++ b/spec/support/app/app/models/preload.rb
@@ -1,0 +1,2 @@
+class Preload < ActiveRecord::Base
+end

--- a/spec/support/app/db/schema.rb
+++ b/spec/support/app/db/schema.rb
@@ -2,6 +2,7 @@ ActiveRecord::Schema.define(:version => 0) do
   begin
     drop_table :users
     drop_table :skills
+    drop_table :preloads
   rescue Exception => e
   end
 
@@ -12,6 +13,10 @@ ActiveRecord::Schema.define(:version => 0) do
   end
 
   add_index :users, :email, :unique => true
+
+  create_table :preloads do |t|
+    t.string :name
+  end
 
   create_table :skills do |t|
     t.references :user

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -8,8 +8,13 @@ FactoryGirl.define do
     f.association :user
   end
 
+  factory :preload do |f|
+    f.name "My Preload"
+  end
+
   preload do
     factory(:john) { create(:user) }
     factory(:ruby) { create(:skill, :user => users(:john)) }
+    factory(:my)   { create(:preload) }
   end
 end


### PR DESCRIPTION
Always use global namespace to lookup models to avoid colliding with factory_girl-preload constants.

Cheers!
