### PR TITLE
Truncate error when using foreign keys

### DIFF
--- a/lib/factory_girl/preload.rb
+++ b/lib/factory_girl/preload.rb
@@ -27,7 +27,7 @@ module FactoryGirl
     def self.clean(*names)
       query = case ActiveRecord::Base.connection.adapter_name
         when "SQLite"     then "DELETE FROM %s"
-        when "PostgreSQL" then "TRUNCATE TABLE %s RESTART IDENTITY"
+        when "PostgreSQL" then "TRUNCATE TABLE %s RESTART IDENTITY CASCADE"
         else "TRUNCATE TABLE %s"
       end
       names = ActiveRecord::Base.descendants.collect(&:table_name).uniq if names.empty?


### PR DESCRIPTION
Automatically truncate all tables that have foreign-key references to any of the named tables, or to any tables added to the group due to CASCADE.
