### PR TITLE
Lazy load all factories

### DIFF
--- a/lib/factory_girl/preload.rb
+++ b/lib/factory_girl/preload.rb
@@ -9,10 +9,12 @@ module FactoryGirl
     class << self
       attr_accessor :preloaders
       attr_accessor :factories
+      attr_accessor :record_ids
     end
 
     self.preloaders = []
     self.factories = {}
+    self.record_ids = {}
 
     def self.active_record
       ActiveRecord::Base
@@ -51,7 +53,7 @@ module FactoryGirl
     def self.reload_factories
       factories.each do |class_name, group|
         group.each do |name, factory|
-          factories[class_name][name] = factory.class.find(factory.id)
+          factories[class_name][name] = nil
         end
       end
     end

--- a/lib/factory_girl/preload/helpers.rb
+++ b/lib/factory_girl/preload/helpers.rb
@@ -31,7 +31,10 @@ module FactoryGirl
 
       private
       def factory_get(name, model)
-        factory = Preload.factories[model.name][name] rescue nil
+        factory = Preload.factories[model.name][name]
+        if factory.blank? && Preload.factories[model.name].has_key?(name)
+          factory = Preload.factories[model.name][name] = model.find(Preload.record_ids[model.name][name])
+        end
         raise "Couldn't find #{name.inspect} factory for #{model.name.inspect} model" unless factory
         factory
       end
@@ -44,6 +47,9 @@ module FactoryGirl
         record = instance_eval(&block)
         Preload.factories[record.class.name] ||= {}
         Preload.factories[record.class.name][name.to_sym] = record
+
+        Preload.record_ids[record.class.name] ||= {}
+        Preload.record_ids[record.class.name][name.to_sym] = record.id
       end
     end
   end

--- a/spec/factory_girl/preload_spec.rb
+++ b/spec/factory_girl/preload_spec.rb
@@ -9,6 +9,15 @@ describe FactoryGirl::Preload do
     FactoryGirl::Preload.preloaders.should include(block)
   end
 
+  it "should lazy load all factories, loading only when used" do
+    FactoryGirl::Preload.record_ids['User'][:john].should eq(1)
+    FactoryGirl::Preload.factories['User'][:john].should be_nil
+
+    user = users(:john)
+
+    FactoryGirl::Preload.factories['User'][:john].should eq(user)
+  end
+
   it "injects model methods" do
     expect { users(:john) }.to_not raise_error
   end


### PR DESCRIPTION
Hi @fnando,

This pull request makes the preloader lazy load all factories. This means that all factories are not reloaded after each spec, and only loaded when used in the spec. 

In our spec suite, since we have a lot of factories, this change saved 1 minute. 
