### PR TITLE
Allow to use preload helpers inside factory definition

### DIFF
--- a/lib/factory_girl/preload/factory_girl.rb
+++ b/lib/factory_girl/preload/factory_girl.rb
@@ -1,0 +1,7 @@
+if defined? FactoryGirl
+  if FactoryGirl::VERSION =~ /^[4-9]|\d{2,}/
+    FactoryGirl::SyntaxRunner.include(FactoryGirl::Preload::Helpers)
+  else
+    FactoryGirl::Proxy.include(FactoryGirl::Preload::Helpers)
+  end
+end


### PR DESCRIPTION
In the application that you are testing add this line to your test helper file:

``` ruby
require 'factory_girl/preload'
require 'factory_girl/preload/factory_girl'
```

Now you can use the helpers outside a preload block:

``` ruby
FactoryGirl.define do
  factory :projects do
    user { users(:john) }
  end
end
```
