### PR TITLE
Sort model files explicitly

### DIFF
--- a/lib/factory_bot/preload/helpers.rb
+++ b/lib/factory_bot/preload/helpers.rb
@@ -8,7 +8,7 @@ module FactoryBot
       def self.load_models
         return unless defined?(Rails)
 
-        Dir[Rails.application.root.join("app/models/**/*.rb")].each do |file|
+        Dir[Rails.application.root.join("app/models/**/*.rb")].sort.each do |file|
           require_dependency file
         end
       end


### PR DESCRIPTION
I changed the sorting mechanism of the loading order of model files to ruby string comparison based one.
Because the order of the results returned by `Dir::[]` depends on the system.

> Case sensitivity depends on your system (File::FNM_CASEFOLD is ignored), as does the order in which the results are returned.

ref. https://ruby-doc.org/core-2.7.2/Dir.html#method-c-glob