### PR TITLE
Use tables method to fetch AR tables

### DIFF
--- a/lib/factory_bot/preload.rb
+++ b/lib/factory_bot/preload.rb
@@ -70,9 +70,7 @@ module FactoryBot
     end
 
     def self.active_record_names
-      names = active_record.descendants.collect(&:table_name).uniq.compact
-
-      names.reject {|name| reserved_tables.include?(name) }
+      connection.tables.reject {|name| reserved_tables.include?(name) }
     end
 
     def self.reload_factories


### PR DESCRIPTION
We've been experiencing some issues with the current way we are fetching table names, which is causing some temporary tables to be deleted, but as they don't exist in the DB, they raise an error.
I have three solutions for this case:
1. Select only the existing tables (which is this PR)
2. Rescue from error (does not seem ideal in my opinion)
3. Check if the table exists before deleting it (slower)

This PR fixes this use case, using a ActiveRecord specific method for fetching the existing tables